### PR TITLE
Remove the From: header from original mail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+v1.2.0-ciencia / 2019-06-09
+===================
+
+  * Remove the "From:" header from original mail (postfix seems to obey it
+    even if wrong)
+  * Add -F parameter to sendmail, to get a nicer sender name instead of
+    "nobody", when removing the From: header
+
 v1.1.1 / 2019-02-22
 ===================
 


### PR DESCRIPTION
Apparently, Postfix sends the mail with the original From: header, which isn't
rewritten, causing DKIM and DMARC to fail validation.

This commit removes the From: header, and adds the -F parameter to sendmail to
specify a nicer sender name. When the From: header was removed, the sender
name is set to "nobody", which is ugly.